### PR TITLE
fix: disable rename input autocomplete

### DIFF
--- a/packages/e2e/src/viewlet.editor-open-rename.ts
+++ b/packages/e2e/src/viewlet.editor-open-rename.ts
@@ -25,4 +25,5 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Wo
   const renameInput = Locator('.RenameInputWrapper > .RenameInputBox')
   await expect(renameInput).toBeVisible()
   await expect(renameInput).toBeFocused()
+  await expect(renameInput).toHaveAttribute('autocomplete', 'off')
 }

--- a/packages/rename-worker/src/parts/GetRenameInputVirtualDom/GetRenameInputVirtualDom.ts
+++ b/packages/rename-worker/src/parts/GetRenameInputVirtualDom/GetRenameInputVirtualDom.ts
@@ -13,6 +13,7 @@ export const getRenameInputVirtualDom = (): readonly VirtualDomNode[] => {
       type: VirtualDomElements.Div,
     },
     {
+      autocomplete: 'off',
       childCount: 0,
       className: MergeClassNames.mergeClassNames(ClassNames.InputBox, ClassNames.RenameInputBox),
       name: InputName.Rename,

--- a/packages/rename-worker/test/GetRenameVirtualDom.test.ts
+++ b/packages/rename-worker/test/GetRenameVirtualDom.test.ts
@@ -21,6 +21,7 @@ test('getRenameVirtualDom', () => {
       type: 4,
     },
     {
+      autocomplete: 'off',
       childCount: 0,
       className: 'InputBox RenameInputBox',
       name: 'Rename',


### PR DESCRIPTION
Disable browser autocomplete on the editor rename input and cover the attribute in the existing rename e2e test.