### PR TITLE
fix: prefill rename input

### DIFF
--- a/packages/rename-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/rename-worker/src/parts/LoadContent/LoadContent.ts
@@ -21,6 +21,7 @@ export const loadContent = async (state: RenameState): Promise<RenameState> => {
     ...state,
     focused: true,
     height,
+    newValue: word,
     oldValue: word,
     selectionEnd,
     version: 1,

--- a/packages/rename-worker/test/LoadContent.test.ts
+++ b/packages/rename-worker/test/LoadContent.test.ts
@@ -34,6 +34,7 @@ test('loadContent - with word at cursor', async () => {
     ...state,
     focused: true,
     height: 80,
+    newValue: 'test',
     oldValue: 'test',
     selectionEnd: 4,
     version: 1,


### PR DESCRIPTION
## Summary
- initialize the rename widget's editable value from the selected word
- keep the existing full-word selection so typing replaces the prefilled name
- cover the initialized value in the load-content test

## Testing
- npm test
- npm run type-check
- npm run lint
- npm run build